### PR TITLE
Fix target specification type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ then re-build the hierarchy.
 Eg:
 
 ```nix
-eachSystem ["x86-64-linux"] (system: { hello = 42; })
-# => { hello.x86-64-linux.hello = 42; }
+eachSystem ["x86_64-linux"] (system: { hello = 42; })
+# => { hello.x86_64-linux.hello = 42; }
 ```
 
 ### `eachDefaultSystem -> (<system> -> attrs)`


### PR DESCRIPTION
Otherwise you get an error `Target specification with 3 components is ambiguous`.