### PR TITLE
implement flattenTreeSystem

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -107,6 +107,11 @@ let
   #   }
   flattenTree = tree: import ./flattenTree.nix tree;
 
+  # It turns out that we also need to filter by the supported system. This is
+  # the same thing as able, but that also looks at meta.hydraPlatforms or
+  # meta.platforms if the former is undefined.
+  flattenTreeSystem = system: tree: import ./flattenTreeSystem.nix system tree;
+
   # Returns the structure used by `nix app`
   mkApp =
     { drv
@@ -128,6 +133,7 @@ let
       eachDefaultSystem
       eachSystem
       flattenTree
+      flattenTreeSystem
       mkApp
       simpleFlake
       ;

--- a/flattenTreeSystem.nix
+++ b/flattenTreeSystem.nix
@@ -1,0 +1,40 @@
+system: tree:
+let
+  op = sum: path: val:
+    let
+      pathStr = builtins.concatStringsSep "/" path;
+    in
+    # Ignore values that are not attrsets
+    if (builtins.typeOf val) != "set" then
+      sum
+    # For derivations
+    else if val ? type && val.type == "derivation" then
+      let
+        meta = val.meta or { };
+        platforms = meta.hydraPlatforms or meta.platforms or [ ];
+      in
+      # Only include those that target this system
+      if builtins.any (p: p == system) platforms then
+        (sum // {
+          # We used to use the derivation outPath as the key, but that crashes Nix
+          # so fallback on constructing a static key
+          "${pathStr}" = val;
+        })
+      else
+        sum
+    # Recurse into attrsets who have that key
+    else if (val.recurseForDerivations or false) == true then
+      recurse sum path val
+    # Ignore that value as well
+    else
+      sum
+  ;
+
+  recurse = sum: path: val:
+    builtins.foldl'
+      (sum: key: op sum (path ++ [ key ]) val.${key})
+      sum
+      (builtins.attrNames val)
+  ;
+in
+recurse { } [ ] tree

--- a/simpleFlake.nix
+++ b/simpleFlake.nix
@@ -55,7 +55,7 @@ let
       legacyPackages = packages;
 
       # Flake expects a flat attrset containing only derivations as values
-      packages = lib.flattenTree packages;
+      packages = lib.flattenTreeSystem system packages;
     }
     //
     (


### PR DESCRIPTION
It turns out that we also need to filter by the supported system to get
a useful output out of flattenTree.

In order to keep back-compat, a new implementation has been created that
also looks at the meta.hydraPlatforms or meta.platforms if the former is
undefined, and only keep the derivations that have the provided system
in it.

Fixes #4