### PR TITLE
simpleFlakes: checks magic for CI

### DIFF
--- a/simpleFlake.nix
+++ b/simpleFlake.nix
@@ -65,6 +65,12 @@ let
     )
     //
     (
+      if packages ? checks then {
+        checks = packages.checks;
+      } else { }
+    )
+    //
+    (
       if shell != null then {
         devShell = shell_ { inherit pkgs; };
       } else if packages ? devShell then {


### PR DESCRIPTION
closes #21 

see: https://github.com/NixOS/nix/blob/master/src/nix/flake-check.md#description

/cc @hamishmack for https://github.com/input-output-hk/haskell.nix/pull/972 

&rarr; would be a nice gesture of higher level pattern consolidation if `haskell.nix` would use / evolve `simpleFlake`, wouldn't it?