### PR TITLE
simpleFlake: use only legacyPackages

### DIFF
--- a/simpleFlake.nix
+++ b/simpleFlake.nix
@@ -52,10 +52,8 @@ let
       packages = pkgs.${name} or { };
     in
     {
+      # Use the legacy packages since it's more forgiving.
       legacyPackages = packages;
-
-      # Flake expects a flat attrset containing only derivations as values
-      packages = lib.flattenTree packages;
     }
     //
     (


### PR DESCRIPTION
Since Flake resolves both namespaces, and legacyPackages is more
forgiving, use that and not deal with the subtle differences.

Fixes #13