### PR TITLE
Add convenient generic attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ eachSystem (defaultSystems ++ ["armv7l-linux"]) (system: { hello = 42; })
 
 ### `eachSystem -> [<system>] -> (<system> -> attrs)`
 
+Alternative usage: `eachSystem -> [<system>] -> { generic = attrs; callback = (<system> -> attrs); }`
+
 A common case is to build the same structure for each system. Instead of
 building the hierarchy manually or per prefix, iterate over each systems and
 then re-build the hierarchy.
@@ -47,6 +49,8 @@ eachSystem allSystems (system: { hello = 42; })
 ```
 
 ### `eachDefaultSystem -> (<system> -> attrs)`
+
+Alternative usage: `eachDefaultSystem -> { generic = attrs; callback = (<system> -> attrs); }`
 
 `eachSystem` pre-populated with `defaultSystems`.
 
@@ -164,4 +168,3 @@ warning: unknown flake output 'lib'
 
 nixpkgs is currently having the same issue so I assume that it will be
 eventually standardized.
-

--- a/default.nix
+++ b/default.nix
@@ -70,7 +70,9 @@ let
           op = attrs: key:
             attrs //
             {
-              ${key} = (attrs.${key} or { }) // { ${system} = ret.${key}; };
+              ${key} = (attrs.${key} or { }) // {
+                ${system} = ret.${key};
+              } // (ret.${key}.generic or { });
             }
           ;
         in

--- a/examples/each-system-callback/flake.lock
+++ b/examples/each-system-callback/flake.lock
@@ -1,0 +1,39 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1615710062,
+        "narHash": "sha256-vnwBC8Y1VKL6siISNav7cjRspkprVUbm7dLI+S9pTZc=",
+        "type": "git",
+        "url": "file:///home/user/Coding/Nix/flake-utils"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1616155360,
+        "narHash": "sha256-KNJXAQKwmPKLejrggFP53GWVO5Hk81XoF0s/byawHww=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "24d3016208bc6140fb416a0c151300b568e48808",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/each-system-callback/flake.nix
+++ b/examples/each-system-callback/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "Flake utils demo";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem {
+      generic =
+        {
+          lib = {
+            system-independent = "hi";
+          };
+        };
+      callback = system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in
+        rec {
+          lib = {
+            system-specific = "hi from ${system}";
+          };
+
+          packages = flake-utils.lib.flattenTree {
+            hello = pkgs.hello;
+            gitAndTools = pkgs.gitAndTools;
+          };
+          defaultPackage = packages.hello;
+          apps.hello = flake-utils.lib.mkApp { drv = packages.hello; };
+          defaultApp = apps.hello;
+        };
+    };
+}

--- a/examples/each-system-callback/test.nix
+++ b/examples/each-system-callback/test.nix
@@ -1,0 +1,1 @@
+(builtins.getFlake (toString ./.)).lib

--- a/examples/each-system/flake.lock
+++ b/examples/each-system/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1616158299,
+        "narHash": "sha256-pEnntZa1fDMb0FWfdN0htAMdvNaM/oRDs31k26Jz5qc=",
+        "ref": "generic",
+        "rev": "0206fc90b7c39e0e982ccda17cf2772d38beb19e",
+        "revCount": 30,
+        "type": "git",
+        "url": "file:///home/user/Coding/Nix/flake-utils"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1616155360,
+        "narHash": "sha256-KNJXAQKwmPKLejrggFP53GWVO5Hk81XoF0s/byawHww=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "24d3016208bc6140fb416a0c151300b568e48808",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/each-system/flake.nix
+++ b/examples/each-system/flake.nix
@@ -7,11 +7,25 @@
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system}; in
       rec {
+        lib = {
+          system = system;
+
+          generic = {
+            inc = a: a + 1;
+          };
+        };
+
         packages = flake-utils.lib.flattenTree {
           hello = pkgs.hello;
           gitAndTools = pkgs.gitAndTools;
+
+          printLib = pkgs.writeShellScriptBin "hello" ''
+            echo ${self.lib."${system}".system}
+            echo ${toString (self.lib.inc 41)}
+          '';
         };
         defaultPackage = packages.hello;
+
         apps.hello = flake-utils.lib.mkApp { drv = packages.hello; };
         defaultApp = apps.hello;
       }

--- a/examples/each-system/flake.nix
+++ b/examples/each-system/flake.nix
@@ -7,25 +7,11 @@
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system}; in
       rec {
-        lib = {
-          system = system;
-
-          generic = {
-            inc = a: a + 1;
-          };
-        };
-
         packages = flake-utils.lib.flattenTree {
           hello = pkgs.hello;
           gitAndTools = pkgs.gitAndTools;
-
-          printLib = pkgs.writeShellScriptBin "hello" ''
-            echo ${self.lib."${system}".system}
-            echo ${toString (self.lib.inc 41)}
-          '';
         };
         defaultPackage = packages.hello;
-
         apps.hello = flake-utils.lib.mkApp { drv = packages.hello; };
         defaultApp = apps.hello;
       }


### PR DESCRIPTION
Doing

```nix
{
  lib = {
    test = 1;
  };
} // eachDefaultSystem (system: {
  packages = { /* ... */ };
})
```

is really inconvenient. This lets you do

```nix
eachDefaultSystem (system: {
  lib.generic = {
    test = 1;
  };
  packages = { /* ... */ };
})
```