### PR TITLE
ref: simplify flattenTree

### DIFF
--- a/flattenTree.nix
+++ b/flattenTree.nix
@@ -21,7 +21,7 @@ let
       sum
   ;
 
-  isAttrs = builtins.isAttrs or (builtins.typeOf val) != "set";
+  isAttrs = builtins.isAttrs or (builtins.typeOf val) == "set";
   isDerivation = x: isAttrs x && x ? type && x.type == "derivation";
 
   recurse = sum: path: val:

--- a/flattenTree.nix
+++ b/flattenTree.nix
@@ -4,11 +4,7 @@ let
     let
       pathStr = builtins.concatStringsSep "/" path;
     in
-    if (builtins.typeOf val) != "set" then
-    # ignore that value
-    # builtins.trace "${pathStr} is not of type set"
-      sum
-    else if val ? type && val.type == "derivation" then
+    if isDerivation val then
     # builtins.trace "${pathStr} is a derivation"
     # we used to use the derivation outPath as the key, but that crashes Nix
     # so fallback on constructing a static key
@@ -24,6 +20,9 @@ let
     # builtins.trace "${pathStr} is something else"
       sum
   ;
+
+  isAttrs = builtins.isAttrs or (builtins.typeOf val) != "set";
+  isDerivation = x: isAttrs x && x ? type && x.type == "derivation";
 
   recurse = sum: path: val:
     builtins.foldl'


### PR DESCRIPTION
People have been complaining about the readability of the code. In particular, the former `flattenTreeSystem` which might have ultimately lead to its abandonment instead of its fixing in the particular context it was abandoned.

Do a decisive preemptive strike, here.