### PR TITLE
filterPackages: add fallbacks for missing attrs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -119,7 +119,7 @@ let
   #   {
   #      hello = «derivation»;
   #   }
-  filterPackages = system: packages: import ./filterPackages.nix system packages;
+  filterPackages = import ./filterPackages.nix { inherit allSystems; };
 
   # Returns the structure used by `nix app`
   mkApp =

--- a/filterPackages.nix
+++ b/filterPackages.nix
@@ -1,3 +1,4 @@
+{ allSystems }:
 system: packages:
 let
   # Adopted from nixpkgs.lib
@@ -18,11 +19,12 @@ let
     let
       inherit (builtins) isAttrs;
       isDerivation = x: isAttrs x && x ? type && x.type == "derivation";
-      platforms = meta.hydraPlatforms or meta.platforms or [ ];
+      isBroken = meta.broken or false;
+      platforms = meta.hydraPlatforms or meta.platforms or allSystems;
     in
       # check for isDerivation, so this is independently useful of
       # flattenTree, which also does filter on derviations
-      isDerivation v && !meta.broken && builtins.elem system platforms
+      isDerivation v && !isBroken && builtins.elem system platforms
   ;
 in
 filterAttrs sieve packages


### PR DESCRIPTION
`meta.broken` and `meta.platforms`/`meta.hydraPlatforms` don't always exist.

for `broken` just assume its not broken if the attribute doesn't exist.
for `platforms` default to the package supporting all platforms.

This is in line with what nixpkgs does in `check-meta.nix`.