### PR TITLE
check-utils: add hasBuilt

### DIFF
--- a/check-utils.nix
+++ b/check-utils.nix
@@ -9,6 +9,10 @@ let
   };
 in
 {
+  hasBuilt = d:
+    if (builtins.tryEval ( builtins.pathExists d)).success
+    then test "SUCCESS__${str d.name}__HAS_BUILT" "echo success > $out"
+    else test "FAILURE__${str d.name}__HAS_NOT_BUILT" "exit 1";
 
   isEqual = a: b:
     if a == b


### PR DESCRIPTION
This implementation of hasBUilt depends on a very simple
IFD (`builtins.pathExists drv`)﻿. It works well for
successful builds, but currently build-errors for failing
ones, despite of the use of `builtins.tryEval`.


I'm investigating if this behaviour of `builtins.tryEval`
can be considered an upstream bug, as long as IFD, per se,
are not forbidden.

(opinion milage may vary)
