### PR TITLE
Add aarch64-darwin to default system list.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@ let
     "i686-linux"
     "x86_64-darwin"
     "x86_64-linux"
+    "aarch64-darwin"
   ];
 
   # List of all systems defined in nixpkgs


### PR DESCRIPTION
From 21.05 nixpkgs is also built by hydra for `aarch64-darwin`, as used on Apple M1 devices. This adds the `aarch64-darwin` platform to the `defaultSystems` list. Many other flakes depend on `defaultSystems` and without this most do not work natively on M1 devices as they do not export any targets for `aarch64-darwin`.