### PR TITLE
Revert "Revert "add aarch64-darwin as default system (#40)""

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,7 @@ let
   # The list of systems supported by nixpkgs and hydra
   defaultSystems = [
     "aarch64-linux"
+    "aarch64-darwin"
     "i686-linux"
     "x86_64-darwin"
     "x86_64-linux"


### PR DESCRIPTION
This reverts commit acfb1951f051283fe3fed23045d09144e0ab5dd2.

This commit was reverted because of ghc is broken on aarch64-darwin.
This is however the wrong conclusion if one package is broken on darwin
than it should be not exposed in a flake or marked as broken accordingly.