### PR TITLE
Make system map more composible

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -79,6 +79,9 @@ let
     in
     builtins.foldl' op { } systems
   ;
+  
+  # Builds a map from <attr>=value to <system>.<attr> = value.
+  eachSystemMap = systems: f: builtins.listToAttrs (builtins.map (system: { name = system; value = f system; }) systems);
 
   # Nix flakes insists on having a flat attribute set of derivations in
   # various places like the `packages` and `checks` attributes.


### PR DESCRIPTION
# About

When making a flake, it would be much more useful if I could compose flake-utils like this

```nix
{
  # ...
  outputs = { self, nixpkgs, flake-utils, ... }: with flake-utils.lib; {
    nixosConfigurations.nixos = ;# ...
    packages = eachSystemMap allSystems (system: import nixpkgs { inherit system; });
    defaultPackage = eachSystemMap allSystems (system: self.packages.${system}.somePackage );
  };
}
```

Rather than having to do this

```nix
{
  # ...
  outputs = { self, nixpkgs, flake-utils, ... }: with flake-utils.lib;
    nixpkgs.lib.mkMerge [
      ({ nixosConfigurations.nixos = ; })
      (eachSystem allSystems (system: {
        packages = import nixpkgs { inherit system; };
        defaultPackage = self.packages.${system}.somePackage;
      }))
  ];
}
```

# Mental model

Coming from other languages, I think this would be more obvious

```nix
# Input
{
  parent = eachSystemMap ["a" "b"] (system: "hello" );
}
# Output
{
  parent = {
    a = "hello";
    b = "hello";
  };
}
```

Than this

```nix
# Input
eachSystemMap ["a" "b"] (system: { parent = "hello";  })
# Output
{
  parent = {
    a = "hello";
    b = "hello";
  };
}
```
