### PR TITLE
add system map for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ flakes.
 
 ## Usage
 
+### `system -> (<system> -> <system>)`
+
+A map from system to system built from `allSystems`. It's mainly useful to
+detect typos and auto-complete if you use
+[rnix-lsp](https://github.com/nix-community/rnix-lsp).
+
+Eg: instead of typing `"x86_64-linux"`, use `system.x86_64-linux`
+
 ### `allSystems -> [<system>]`
 
 A list of all systems defined in nixpkgs. For a smaller list see `defaultSystems`
@@ -22,7 +30,7 @@ The list of systems supported by nixpkgs and built by hydra.
 Useful if you want add additional platforms:
 
 ```nix
-eachSystem (defaultSystems ++ ["armv7l-linux"]) (system: { hello = 42; })
+eachSystem (defaultSystems ++ [system.armv7l-linux]) (system: { hello = 42; })
 ```
 
 ### `eachSystem -> [<system>] -> (<system> -> attrs)`
@@ -34,7 +42,7 @@ then re-build the hierarchy.
 Eg:
 
 ```nix
-eachSystem ["x86_64-linux"] (system: { hello = 42; })
+eachSystem [ system.x86_64-linux ] (system: { hello = 42; })
 # => { hello = { x86_64-linux = 42; }; }
 eachSystem allSystems (system: { hello = 42; })
 # => {
@@ -132,7 +140,7 @@ Input:
 , # maps to the devShell output. Pass in a shell.nix file or function.
   shell ? null
 , # pass the list of supported systems
-  systems ? [ "x86_64-linux" ]
+  systems ? [ system.x86_64-linux ]
 }: null
 ```
 

--- a/default.nix
+++ b/default.nix
@@ -57,6 +57,14 @@ let
     "x86_64-genode"
   ];
 
+  # A map from system to system. It's useful to detect typos.
+  #
+  # Instead of typing `"x86_64-linux"`, type `flake-utils.lib.system.x86_64-linux`
+  # and get an error back if you used a dash instead of an underscore.
+  system =
+    builtins.listToAttrs
+      (map (system: { name = system; value = system; }) allSystems);
+
   # eachSystem using defaultSystems
   eachDefaultSystem = eachSystem defaultSystems;
 
@@ -183,6 +191,7 @@ let
       flattenTree
       mkApp
       simpleFlake
+      system
       ;
   };
 in


### PR DESCRIPTION
Transform typos into key access errors. Typing "x86_64-linux" is always a bit of a nightmare to remember where there is a dash, an underscore. Use `flake-utilse.lib.system.x86_64-linux` instead.