### PR TITLE
Bugfix: simpleFlake works only on x86 and Linux

### DIFF
--- a/simpleFlake.nix
+++ b/simpleFlake.nix
@@ -18,7 +18,7 @@
 , # maps to the devShell output. Pass in a shell.nix file or function.
   shell ? null
 , # pass the list of supported systems
-  systems ? [ "x86_64-linux" ]
+  systems ? [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ]
 }:
 let
   loadOverlay = obj:


### PR DESCRIPTION
I've discovered this while trying to use it on a M1 Macbook (an `aarch64-darwin` system).
The change makes sure simpleFlake works by default on most systems.
The user would use this parameter only to restrict the systems if necessary.