### PR TITLE
feat: add convenience eachDefaultSystemMap

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -120,6 +120,9 @@ let
     in
     builtins.foldl' op { } systems
   ;
+
+  # eachSystemMap using defaultSystems
+  eachDefaultSystemMap = eachSystemMap defaultSystems;
   
   # Builds a map from <attr>=value to <system>.<attr> = value.
   eachSystemMap = systems: f: builtins.listToAttrs (builtins.map (system: { name = system; value = f system; }) systems);
@@ -190,6 +193,7 @@ let
       defaultSystems
       eachDefaultSystem
       eachSystem
+      eachDefaultSystemMap
       eachSystemMap
       filterPackages
       flattenTree


### PR DESCRIPTION
Hello!

As mentioned in https://github.com/numtide/flake-utils/issues/59, `eachSystemMap` is really powerful now (and helps avoid using `//`).

It would be nice if we had a `eachDefaultSystemMap = eachSystemMap defaultSystems`, so we don't have to `let` it in every flake. So here it is.

For reference, here's an example flake that outputs a module and a package using `eachDefaultSystem` (with the older `defaultPackage` and co):
```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
    utils.url = "github:numtide/flake-utils";
  };

  outputs = { self, nixpkgs, utils }:
    rec {
      nixosModules.example = import ./module.nix;
      nixosModule = nixosModules.example;
    } // (utils.lib.eachDefaultSystem (system: rec {
      packages.example = (import nixpkgs { inherit system; }).callPackage ./default.nix { };
      defaultPackage = packages.example;
    }));
}
```

And using `eachDefaultSystemMap` (with the newer *.default attribute):
```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
    utils.url = "github:misterio77/flake-utils/each-default-system-map";
  };

  outputs = { self, nixpkgs, utils }: {
    nixosModules = rec {
      example = import ./module.nix;
      default = example;
    };

    packages = utils.lib.eachDefaultSystemMap (system: rec {
      example = (import nixpkgs { inherit system; }).callPackage ./default.nix { };
      default = example;
    });
  };
}
```

Thanks!