### PR TITLE
Ensure derivation name length limits are respected in check-utils

### DIFF
--- a/check-utils.nix
+++ b/check-utils.nix
@@ -29,7 +29,8 @@ let
   str = it: if it == null then "null" else (sanitizeDerivationName it);
 
   test = name: command: derivation {
-    inherit name system;
+    inherit system;
+    name = str name;
     builder = "/bin/sh";
     args = [ "-c" command ];
   };


### PR DESCRIPTION
Currently, the length limits aren't respected because the check-util helpers combine both inputs together and doesn't check that their combined length is less than 211.

This fixes that by sanitizing the final combined name as well (which should be a no-op on smaller inputs)