### PR TITLE
import callLocklessFlake

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ Input:
 }: null
 ```
 
+### `callLocklessFlake -> { path, inputs ? { } } -> attrs`
+
+Imports a flake.nix without acknowledging its lock file, useful for
+referencing subflakes from a parent flake. The second argument allows
+specifying the inputs of this flake.
+
+Example:
+```
+callLocklessFlake {
+  path = ./directoryContainingFlake;
+  inputs = { inherit nixpkgs; };
+}
+```
+
 #### Example
 
 Here is how it looks like in practice:

--- a/call-lockless-flake.nix
+++ b/call-lockless-flake.nix
@@ -1,0 +1,16 @@
+/*
+  Imports a flake.nix without acknowledging its lock file, useful for
+  referencing subflakes from a parent flake. The second argument allows
+  specifying the inputs of this flake.
+  Example:
+    callLocklessFlake {
+      path = ./directoryContainingFlake;
+      inputs = { inherit nixpkgs; };
+    }
+*/
+{ path, inputs ? { } }:
+let
+  self = { outPath = path; } //
+    ((import (path + "/flake.nix")).outputs (inputs // { self = self; }));
+in
+self

--- a/default.nix
+++ b/default.nix
@@ -192,6 +192,8 @@ let
   #   }
   filterPackages = import ./filterPackages.nix { inherit allSystems; };
 
+  callLocklessFlake = import ./call-lockless-flake.nix;
+
   # Returns the structure used by `nix app`
   mkApp =
     { drv


### PR DESCRIPTION
This function was added to nixpkgs in
https://github.com/NixOS/nixpkgs/pull/167947 by @MatthewCroughan.
And later reverted because it's for unstable flakes.

So let's add it here, since a lot of projects are already importing
flake-utils.
