### PR TITLE
Prefer `import nixpkgs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ eachSystem allSystems (system: { hello = 42; })
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system}; in
+      let pkgs = import nixpkgs { inherit system; }; in
       rec {
         packages = flake-utils.lib.flattenTree {
           hello = pkgs.hello;

--- a/examples/each-system/flake.nix
+++ b/examples/each-system/flake.nix
@@ -5,7 +5,7 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system}; in
+      let pkgs = import nixpkgs { inherit system; }; in
       rec {
         packages = flake-utils.lib.flattenTree {
           hello = pkgs.hello;


### PR DESCRIPTION
Avoid using `legacyPackages` and use `import nixpkgs` instead. The
latter has the advantage of being easier to extend. For example, with
overlays:

    pkgs = import nixpkgs {
      overlays = [ self.overlays.default ];
      inherit system;
    };