### PR TITLE
Fix `filterPackages` to match platform filtering done by Nixpkgs

### DIFF
--- a/filterPackages.nix
+++ b/filterPackages.nix
@@ -22,10 +22,12 @@ let
       isDerivation = x: isAttrs x && x ? type && x.type == "derivation";
       isBroken = meta.broken or false;
       platforms = meta.hydraPlatforms or meta.platforms or allSystems;
+      badPlatforms = meta.badPlatforms or [ ];
     in
     # check for isDerivation, so this is independently useful of
       # flattenTree, which also does filter on derviations
-    isDerivation v && !isBroken && builtins.elem system platforms
+    isDerivation v && !isBroken && (builtins.elem system platforms) &&
+    !(builtins.elem system badPlatforms)
   ;
 in
 filterAttrs sieve packages

--- a/filterPackages.nix
+++ b/filterPackages.nix
@@ -21,7 +21,7 @@ let
       inherit (builtins) isAttrs;
       isDerivation = x: isAttrs x && x ? type && x.type == "derivation";
       isBroken = meta.broken or false;
-      platforms = meta.hydraPlatforms or meta.platforms or allSystems;
+      platforms = meta.platforms or allSystems;
       badPlatforms = meta.badPlatforms or [ ];
     in
     # check for isDerivation, so this is independently useful of

--- a/filterPackages.nix
+++ b/filterPackages.nix
@@ -25,7 +25,7 @@ let
       badPlatforms = meta.badPlatforms or [ ];
     in
     # check for isDerivation, so this is independently useful of
-      # flattenTree, which also does filter on derviations
+      # flattenTree, which also does filter on derivations
     isDerivation v && !isBroken && (builtins.elem system platforms) &&
     !(builtins.elem system badPlatforms)
   ;


### PR DESCRIPTION
The filtering done by `filterPackages` did not match the behavior of Nixpkgs code:

- `filterPackages` used the `meta.hydraPlatforms` attribute in preference to `meta.platforms`; however, the actual purpose of `meta.hydraPlatforms` is to disable Hydra builds, not to prevent building of the corresponding packages locally, therefore using `meta.hydraPlatforms` resulted in `filterPackages` removing some working packages from the returned set. In particular, wrapper packages like `firefox` or `neovim` were affected (those packages have `meta.hydraPlatforms = []`, because their build process is trivial, and putting the results in the binary cache does not help much).
- `filterPackages` did not handle the `meta.badPlatforms` attribute, therefore some definitely incompatible packages could still pass through the filter.

Update the `filterPackages` code to match the [filtering done by Nixpkgs](https://github.com/NixOS/nixpkgs/blob/c49e4ce3fc0cebbe3e0cba75f0ea86bf28a76b1a/pkgs/stdenv/generic/check-meta.nix#L61-L63). Also fix a typo in a comment in the same area.

Fixes #73.