### PR TITLE
Update each-system template to use new flake output system

### DIFF
--- a/examples/each-system/flake.nix
+++ b/examples/each-system/flake.nix
@@ -6,14 +6,15 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system}; in
-      rec {
-        packages = flake-utils.lib.flattenTree {
+      {
+        packages = rec {
           hello = pkgs.hello;
-          gitAndTools = pkgs.gitAndTools;
+          default = hello;
         };
-        defaultPackage = packages.hello;
-        apps.hello = flake-utils.lib.mkApp { drv = packages.hello; };
-        defaultApp = apps.hello;
+        apps = rec {
+          hello = flake-utils.lib.mkApp { drv = self.packages.${system}.hello; };
+          default = hello;
+        };
       }
     );
 }


### PR DESCRIPTION
This PR updates the `each-system` template to conform to recent changes in flake outputs, specifically that `{apps|packages}.default` has replaced `default{App|Package}`. It also removes the `gitAndTools` package, which doesn't work, as the `gitAndTools` attribute of Nixpkgs isn't a derivation.