### PR TITLE
eachSystem: prefix system-less outpus with `_`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -128,12 +128,20 @@ let
           op = attrs: key:
             let
               appendSystem = key: system: ret:
-                if key == "hydraJobs"
+                if builtins.substring 0 1 key == "_"
+                then ret.${key}
+                else if key == "hydraJobs"
                   then (pushDownSystem system (attrs.hydraJobs or {}) ret.hydraJobs)
                   else { ${system} = ret.${key}; };
             in attrs //
               {
-                ${key} = (attrs.${key} or { })
+                ${
+                  if builtins.substring 0 2 key == "__"
+                  then key
+                  else if builtins.substring 0 1 key == "_"
+                  then builtins.substring 1 (-1) key
+                  else key
+                } = (attrs.${key} or { })
                   // (appendSystem key system ret);
               }
           ;


### PR DESCRIPTION
Enhances `eachSystem` and the functions that build off of it to pass through system-independant outputs such as `lib` by simply prefixing it with `_`: `_lib`.

In additional, attributes prefixed with 2 (`__`) underscores are passed through unmodified, for the sake of `__functor` _et al_.

Currently in use [here](https://github.com/divnix/nosys/blob/d3f3b45944adf3102f4b50ff2d145bdc8e48c3f8/eachSys.nix#L1-L2), but I'd rather use this as an upstream, or possibly even merge the `noSys` and `deSys` functions here if you are open to it.
