### PR TITLE
Support for nested attributes

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -26,53 +26,19 @@ let
   # eachSystem using defaultSystems
   eachDefaultSystem = eachSystem defaultSystems;
 
-  # Builds a map from <attr>=value to <attr>.<system>=value for each system,
-  # except for the `hydraJobs` attribute, where it maps the inner attributes,
-  # from hydraJobs.<attr>=value to hydraJobs.<attr>.<system>=value.
+  # Builds a map from <attr>=value to <attr>.<system>=value for each system
   #
   eachSystem = systems: f:
     let
-      # Taken from <nixpkgs/lib/attrsets.nix>
-      isDerivation = x: builtins.isAttrs x && x ? type && x.type == "derivation";
-
-      # Used to match Hydra's convention of how to define jobs. Basically transforms
-      #
-      #     hydraJobs = {
-      #       hello = <derivation>;
-      #       haskellPackages.aeson = <derivation>;
-      #     }
-      #
-      # to
-      #
-      #     hydraJobs = {
-      #       hello.x86_64-linux = <derivation>;
-      #       haskellPackages.aeson.x86_64-linux = <derivation>;
-      #     }
-      #
-      # if the given flake does `eachSystem [ "x86_64-linux" ] { ... }`.
-      pushDownSystem = system: merged:
-        builtins.mapAttrs
-          (name: value:
-            if ! (builtins.isAttrs value) then value
-            else if isDerivation value then (merged.${name} or { }) // { ${system} = value; }
-            else pushDownSystem system (merged.${name} or { }) value);
-
       # Merge together the outputs for all systems.
       op = attrs: system:
         let
           ret = f system;
-          op = attrs: key:
-            let
-              appendSystem = key: system: ret:
-                if key == "hydraJobs"
-                then (pushDownSystem system (attrs.hydraJobs or { }) ret.hydraJobs)
-                else { ${system} = ret.${key}; };
-            in
-            attrs //
-            {
-              ${key} = (attrs.${key} or { })
-              // (appendSystem key system ret);
-            }
+          op = attrs: key: attrs //
+              {
+                ${key} = (attrs.${key} or { })
+                  // { ${system} = ret.${key}; };
+              }
           ;
         in
         builtins.foldl' op attrs (builtins.attrNames ret);


### PR DESCRIPTION
We noticed that `eachSystem` removes things from `hydraJobs` if you use nested attributes (instead of single flat attribute set).  At first we solved this problem by using `recursiveUpdate` instead of `//` and this worked and kept the transform to "Hydra's convention" in place (see the first commit in this PR for this change).

We noticed that our eval times when nothing needed building were unusually high (40m).   It was not made worse by the fix, but we wondered if the transform itself was the problem.  We experimented with removing the special treatment of `hydraJobs` instead.  As well as fixing the nested attribute problem it made evaluation 4x faster (around 10m).  It may be a coincidence, but we have 4 supported systems.

See https://github.com/input-output-hk/haskell.nix/pull/1886