### PR TITLE
Update documentation for the `systems` argument of `simpleFlake`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Input:
 , # maps to the devShell output. Pass in a shell.nix file or function.
   shell ? null
 , # pass the list of supported systems
-  systems ? [ system.x86_64-linux ]
+  systems ? [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ]
 }: null
 ```
 


### PR DESCRIPTION
in [the code](https://github.com/numtide/flake-utils/blob/411e8764155aa9354dbcd6d5faaeb97e9e3dce24/simpleFlake.nix#L2), the default value for the `systems` argument of `simpleFlake` is:
```nix
[ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ]
```
however, the `README` claims that the default is something different:
```nix
[ system.x86_64-linux ]
```
this pull request updates the `README` to state the correct value.

thanks!