### PR TITLE
deprecate `mkApp` in favor of direct definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,16 +100,21 @@ eachSystem allSystems (system: { hello = 42; })
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system}; in
       {
-        packages = rec {
-          hello = pkgs.hello;
-          default = hello;
+        packages = {
+          default = pkgs.hello;
+          # `nix run .#find` will work because findutils.meta.mainProgram is set to "find".
+          find = pkgs.findutils;
         };
-        apps = rec {
-          hello = {
-            type = "app";
-            program = "${nixpkgs.lib.getExe self.packages.${system}.hello}";
+        # Use apps to expose packages that have multiple binaries.
+        apps = {
+          xargs = flake-utils.lib.mkApp {
+            drv = pkgs.findutils;
+            name = "xargs";
           };
-          default = hello;
+          ls = flake-utils.lib.mkApp {
+            drv = pkgs.coreutils;
+            name = "ls";
+          };
         };
       }
     );

--- a/README.md
+++ b/README.md
@@ -127,15 +127,16 @@ Meld merges subflakes using common inputs.  Useful when you want to
 split up a large flake with many different components into more
 manageable parts.
 
-### `mkApp { drv, name ? drv.pname or drv.name, exePath ? drv.passthru.exePath or "/bin/${name}"`
+### `mkApp { drv, name ? drv.pname or drv.name, exePath ? "/bin/${name}"`
 
 > **DEPRECATED**
 >
-> `mkApp` has been deprecated in favor of direct definitions.
+> `mkApp` used to look for `drv.passthru.exePath`, and it's no longer the case.
 >
-> Example: `{ type = "app"; program = nixpkgs.lib.getExe drv; }`
+> For derivations that only expose a single binary, set the `meta.mainProgram`
+> attribute on the package and expose it in the `packages`.
 
-A small utility that builds the structure expected by the special `apps` and `defaultApp` prefixes.
+A small utility that builds the structure expected by the special `apps` prefix.
 
 
 ### `flattenTree :: attrs -> attrs`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ eachSystem allSystems (system: { hello = 42; })
           default = hello;
         };
         apps = rec {
-          hello = flake-utils.lib.mkApp { drv = self.packages.${system}.hello; };
+          hello = {
+            type = "app";
+            program = "${nixpkgs.lib.getExe self.packages.${system}.hello}";
+          };
           default = hello;
         };
       }
@@ -120,6 +123,12 @@ split up a large flake with many different components into more
 manageable parts.
 
 ### `mkApp { drv, name ? drv.pname or drv.name, exePath ? drv.passthru.exePath or "/bin/${name}"`
+
+> **DEPRECATED**
+>
+> `mkApp` has been deprecated in favor of direct definitions.
+>
+> Example: `{ type = "app"; program = "${nixpkgs.lib.getExe drv}"; }`
 
 A small utility that builds the structure expected by the special `apps` and `defaultApp` prefixes.
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ manageable parts.
 >
 > `mkApp` has been deprecated in favor of direct definitions.
 >
-> Example: `{ type = "app"; program = "${nixpkgs.lib.getExe drv}"; }`
+> Example: `{ type = "app"; program = nixpkgs.lib.getExe drv; }`
 
 A small utility that builds the structure expected by the special `apps` and `defaultApp` prefixes.
 

--- a/examples/each-system/flake.nix
+++ b/examples/each-system/flake.nix
@@ -7,16 +7,21 @@
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system}; in
       {
-        packages = rec {
-          hello = pkgs.hello;
-          default = hello;
+        packages = {
+          default = pkgs.hello;
+          # `nix run .#find` will work because findutils.meta.mainProgram is set to "find".
+          find = pkgs.findutils;
         };
-        apps = rec {
-          hello = {
-            type = "app";
-            program = nixpkgs.lib.getExe self.packages.${system}.hello;
+        # Use apps to expose packages that have multiple binaries.
+        apps = {
+          xargs = flake-utils.lib.mkApp {
+            drv = pkgs.findutils;
+            name = "xargs";
           };
-          default = hello;
+          ls = flake-utils.lib.mkApp {
+            drv = pkgs.coreutils;
+            name = "ls";
+          };
         };
       }
     );

--- a/examples/each-system/flake.nix
+++ b/examples/each-system/flake.nix
@@ -14,7 +14,7 @@
         apps = rec {
           hello = {
             type = "app";
-            program = "${nixpkgs.lib.getExe self.packages.${system}.hello}";
+            program = nixpkgs.lib.getExe self.packages.${system}.hello;
           };
           default = hello;
         };

--- a/examples/each-system/flake.nix
+++ b/examples/each-system/flake.nix
@@ -12,7 +12,10 @@
           default = hello;
         };
         apps = rec {
-          hello = flake-utils.lib.mkApp { drv = self.packages.${system}.hello; };
+          hello = {
+            type = "app";
+            program = "${nixpkgs.lib.getExe self.packages.${system}.hello}";
+          };
           default = hello;
         };
       }

--- a/lib.nix
+++ b/lib.nix
@@ -211,10 +211,14 @@ let
   in
     { drv
     , name ? drv.pname or drv.name
-    , exePath ? drv.passthru.exePath or "/bin/${name}"
+    , exePath ? "/bin/${name}"
     }:
+    (if (drv.passthru or {}) ? exePath then
     warn
-      "`mkApp` has been deprecated in favor of direct definitions. Replace definitions of `mkApp { drv = ...; }` with `{ type = \"app\"; program = \"\${nixpkgs.lib.getExe drv}\"; }`, and definitions of `mkApp { drv = ...; name = \"abc\"; }` with `{ type = \"app\"; program = \"\${drv}/bin/abc\"; }` to remove this warning. Use of `passthru.exePath` inside derivations should be replaced with nixpkgs's `meta.mainProgram` instead."
+      "flake-utils.lib.mkApp: ${name} has the deprecated `drv.passthru.exePath` attribute. Please pass the `exePath` directly."
+    else
+      lib.id
+    )
     {
       type = "app";
       program = "${drv}${exePath}";

--- a/lib.nix
+++ b/lib.nix
@@ -202,11 +202,19 @@ let
     recursiveUpdate output (import subflake inputs)) { };
 
   # Returns the structure used by `nix app`
-  mkApp =
+  mkApp = let
+    # Pulled from nixpkgs.lib
+    warn =
+      if builtins.elem (builtins.getEnv "NIX_ABORT_ON_WARN") ["1" "true" "yes"]
+      then msg: builtins.trace "[1;31mwarning: ${msg}[0m" (abort "NIX_ABORT_ON_WARN=true; warnings are treated as unrecoverable errors.")
+      else msg: builtins.trace "[1;31mwarning: ${msg}[0m";
+  in
     { drv
     , name ? drv.pname or drv.name
     , exePath ? drv.passthru.exePath or "/bin/${name}"
     }:
+    warn
+      "`mkApp` has been deprecated in favor of direct definitions. Replace definitions of `mkApp { drv = ...; }` with `{ type = \"app\"; program = \"\${nixpkgs.lib.getExe drv}\"; }`, and definitions of `mkApp { drv = ...; name = \"abc\"; }` with `{ type = \"app\"; program = \"\${drv}/bin/abc\"; }` to remove this warning. Use of `passthru.exePath` inside derivations should be replaced with nixpkgs's `meta.mainProgram` instead."
     {
       type = "app";
       program = "${drv}${exePath}";


### PR DESCRIPTION
Now that nixpkgs has its own idea of `passthru.exePath` under the name `meta.mainProgram`, deprecate our solution in favor of the new standard.

This subsequently removes the value of which `mkApp` brings, and therefore a full deprecation for its removal has begun.

Closes: #65