### PR TITLE
fix: allow non-flake `systems` flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,6 +6,7 @@
       }
     },
     "systems": {
+      "flake": false,
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   description = "Pure Nix flake utility functions";
 
   # Externally extensible flake systems. See <https://github.com/nix-systems/nix-systems>.
+  inputs.systems.flake = false;
   inputs.systems.url = "github:nix-systems/default";
 
   outputs = { self, systems }: {


### PR DESCRIPTION
Per convention.