### PR TITLE
Add the current system if --impure is supplied

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -43,7 +43,15 @@ let
         in
         builtins.foldl' op attrs (builtins.attrNames ret);
     in
-    builtins.foldl' op { } systems
+    builtins.foldl' op { }
+      (systems
+       ++ # add the current system if --impure is used
+          (if builtins?currentSystem then
+             if builtins.elem builtins.currentSystem systems
+             then []
+             else [ builtins.currentSystem ]
+           else
+             []))
   ;
 
   # eachSystemMap using defaultSystems


### PR DESCRIPTION
This is a simple way to get things to work on a system that isn't explicitly defined. Since so many projects use flake utils, baking it in here seems like a good option for giving people an escape hatch when then need it.