### PR TITLE
lib: `eachDefaultSystemPassThrough`/`eachSystemPassThrough`: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ eachSystem allSystems (system: { hello = 42; })
 }
 ```
 
+### `eachSystemPassThrough :: [<system>] -> (<system> -> attrs)`
+
+Unlike `eachSystem`, this function does not inject the `${system}` key by merely
+providing the system argument to the function.
+
 ### `eachDefaultSystem :: (<system> -> attrs)`
 
 `eachSystem` pre-populated with `defaultSystems`.
@@ -111,6 +116,24 @@ eachSystem allSystems (system: { hello = 42; })
       }
     );
 }
+```
+
+### `eachDefaultSystemPassThrough :: (<system> -> attrs)`
+
+`eachSystemPassThrough` pre-populated with `defaultSystems`.
+
+#### Example
+
+```nix
+inputs.flake-utils.lib.eachDefaultSystem (system: {
+  checks./*<SYSTEM>.*/"<CHECK>" = /* ... */;
+  devShells./*<SYSTEM>.*/"<DEV_SHELL>" = /* ... */;
+  packages./*<SYSTEM>.*/"<PACKAGE>" = /* ... */;
+})
+// inputs.flake-utils.lib.eachDefaultSystemPassThrough (system: {
+  homeConfigurations."<HOME_CONFIGURATION>" = /* ... */;
+  nixosConfigurations."<NIXOS_CONFIGURATION>" = /* ... */;
+})
 ```
 
 ### `meld :: attrs -> [ path ] -> attrs`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ system = {
 ```
 It's mainly useful to
 detect typos and auto-complete if you use [rnix-lsp](https://github.com/nix-community/rnix-lsp).
-   
+
 Eg: instead of typing `"x86_64-linux"`, use `system.x86_64-linux`.
 
 

--- a/lib.nix
+++ b/lib.nix
@@ -198,8 +198,8 @@ let
       check-utils
       defaultSystems
       eachDefaultSystem
-      eachSystem
       eachDefaultSystemMap
+      eachSystem
       eachSystemMap
       filterPackages
       flattenTree

--- a/lib.nix
+++ b/lib.nix
@@ -28,31 +28,39 @@ let
 
   # Builds a map from <attr>=value to <attr>.<system>=value for each system
   #
-  eachSystem = systems: f:
+  eachSystem =
+    systems: f:
     let
       # Merge together the outputs for all systems.
-      op = attrs: system:
+      op =
+        attrs: system:
         let
           ret = f system;
-          op = attrs: key: attrs //
-              {
-                ${key} = (attrs.${key} or { })
-                  // { ${system} = ret.${key}; };
-              }
-          ;
+          op =
+            attrs: key:
+            attrs
+            // {
+              ${key} = (attrs.${key} or { }) // {
+                ${system} = ret.${key};
+              };
+            };
         in
         builtins.foldl' op attrs (builtins.attrNames ret);
     in
-    builtins.foldl' op { }
-      (systems
-       ++ # add the current system if --impure is used
-          (if builtins?currentSystem then
-             if builtins.elem builtins.currentSystem systems
-             then []
-             else [ builtins.currentSystem ]
-           else
-             []))
-  ;
+    builtins.foldl' op { } (
+      systems
+      ++
+        # add the current system if --impure is used
+        (
+          if builtins ? currentSystem then
+            if builtins.elem builtins.currentSystem systems then
+              [ ]
+            else
+              [ builtins.currentSystem ]
+          else
+            [ ]
+        )
+    );
 
   # eachSystemMap using defaultSystems
   eachDefaultSystemMap = eachSystemMap defaultSystems;

--- a/lib.nix
+++ b/lib.nix
@@ -26,12 +26,11 @@ let
   # eachSystem using defaultSystems
   eachDefaultSystem = eachSystem defaultSystems;
 
-  # Builds a map from <attr>=value to <attr>.<system>=value for each system
-  #
+  # Builds a map from <attr>=value to <attr>.<system>=value for each system.
   eachSystem =
     systems: f:
     let
-      # Merge together the outputs for all systems.
+      # Merge outputs for each system.
       op =
         attrs: system:
         let
@@ -50,7 +49,7 @@ let
     builtins.foldl' op { } (
       systems
       ++
-        # add the current system if --impure is used
+        # Add the current system if the --impure flag is used.
         (
           if builtins ? currentSystem then
             if builtins.elem builtins.currentSystem systems then

--- a/lib.nix
+++ b/lib.nix
@@ -52,11 +52,10 @@ let
         ++
           # Add the current system if the --impure flag is used.
           (
-            if builtins ? currentSystem then
-              if builtins.elem builtins.currentSystem systems then
-                [ ]
-              else
-                [ builtins.currentSystem ]
+            if
+              builtins ? currentSystem && !builtins.elem builtins.currentSystem systems
+            then
+              [ builtins.currentSystem ]
             else
               [ ]
           )

--- a/lib.nix
+++ b/lib.nix
@@ -48,17 +48,13 @@ let
       )
       { }
       (
-        systems
-        ++
+        if
+          !builtins ? currentSystem || builtins.elem builtins.currentSystem systems
+        then
+          systems
+        else
           # Add the current system if the --impure flag is used.
-          (
-            if
-              builtins ? currentSystem && !builtins.elem builtins.currentSystem systems
-            then
-              [ builtins.currentSystem ]
-            else
-              [ ]
-          )
+          systems ++ [ builtins.currentSystem ]
       );
 
   # eachSystemMap using defaultSystems

--- a/lib.nix
+++ b/lib.nix
@@ -29,37 +29,38 @@ let
   # Builds a map from <attr>=value to <attr>.<system>=value for each system.
   eachSystem =
     systems: f:
-    let
-      # Merge outputs for each system.
-      op =
+    builtins.foldl'
+      (
+        # Merge outputs for each system.
         attrs: system:
         let
           ret = f system;
-          op =
-            attrs: key:
-            attrs
-            // {
-              ${key} = (attrs.${key} or { }) // {
-                ${system} = ret.${key};
-              };
-            };
         in
-        builtins.foldl' op attrs (builtins.attrNames ret);
-    in
-    builtins.foldl' op { } (
-      systems
-      ++
-        # Add the current system if the --impure flag is used.
-        (
-          if builtins ? currentSystem then
-            if builtins.elem builtins.currentSystem systems then
-              [ ]
+        builtins.foldl' (
+          attrs: key:
+          attrs
+          // {
+            ${key} = (attrs.${key} or { }) // {
+              ${system} = ret.${key};
+            };
+          }
+        ) attrs (builtins.attrNames ret)
+      )
+      { }
+      (
+        systems
+        ++
+          # Add the current system if the --impure flag is used.
+          (
+            if builtins ? currentSystem then
+              if builtins.elem builtins.currentSystem systems then
+                [ ]
+              else
+                [ builtins.currentSystem ]
             else
-              [ builtins.currentSystem ]
-          else
-            [ ]
-        )
-    );
+              [ ]
+          )
+      );
 
   # eachSystemMap using defaultSystems
   eachDefaultSystemMap = eachSystemMap defaultSystems;


### PR DESCRIPTION
This patchset introduces the `eachDefaultSystemPassThrough` and `eachSystemPassThrough` functions after cleaning up the `README.md` file and the `eachSystem` function.

The rationale for adding these new functions is outlined in the commit message:

> ```patch
> commit d29791e13d0b7f83bdaaa89d09c388d7058d14ab
> Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
> Date:   2024-09-11 20:13:13 +0200
>
>     lib: eachDefaultSystemPassThrough/eachSystemPassThrough: init
>
>     Expose the eachDefaultSystemPassThrough and eachSystemPassThrough
>     functions to handle cases where the system key should not be injected by
>     eachDefaultSystem and eachSystem:
>
>         inputs.flake-utils.lib.eachDefaultSystem (system: {
>           checks./*<SYSTEM>.*/"<CHECK>" = /* ... */;
>           devShells./*<SYSTEM>.*/"<DEV_SHELL>" = /* ... */;
>           packages./*<SYSTEM>.*/"<PACKAGE>" = /* ... */;
>         })
>         // inputs.flake-utils.lib.eachDefaultSystemPassThrough (system: {
>           homeConfigurations."<HOME_CONFIGURATION>" = /* ... */;
>           nixosConfigurations."<NIXOS_CONFIGURATION>" = /* ... */;
>         })
>
>     These functions prevent users from re-implementing simplified
>     eachDefaultSystem and eachSystem versions to avoid system key
>     injections, while benefiting from current and future complex logic, like
>     handling the '--impure' flag.
>
>     This addresses flake-utils' arguably biggest issue. [1]
>
>     [1]: https://ayats.org/blog/no-flake-utils
> ```

Feel free to propose alternative names for the `eachDefaultSystemPassThrough` and `eachSystemPassThrough` functions.

---

For reference, the new `eachDefaultSystemPassThrough` function simplifies my Home Manager setup as follows:

```patch
From e7de6c697d32f96cfdd9a734a21222099b6f204e Mon Sep 17 00:00:00 2001
From: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date: Wed, 11 Sep 2024 22:59:10 +0200
Subject: [PATCH] flake: homeConfigurations: simplify using
 eachDefaultSystemPassThrough

---
 flake.lock | 11 ++++++-----
 flake.nix  | 54 +++++++++++++++++-------------------------------------
 2 files changed, 23 insertions(+), 42 deletions(-)

diff --git a/flake.lock b/flake.lock
index 29433673..659a51bd 100644
--- a/flake.lock
+++ b/flake.lock
@@ -185,15 +185,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
+        "lastModified": 1726087187,
+        "narHash": "sha256-kTivZ/poSIsh9nRpA3i3ozwz9xTlK75zDzRU4KJ6Mqw=",
+        "owner": "trueNAHO",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "d29791e13d0b7f83bdaaa89d09c388d7058d14ab",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
+        "owner": "trueNAHO",
+        "ref": "lib-each-default-system-pass-through-each-system-pass-through-init",
         "repo": "flake-utils",
         "type": "github"
       }
diff --git a/flake.nix b/flake.nix
index b2e8129d..72513131 100644
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@

     flake-utils = {
       inputs.systems.follows = "systems";
-      url = "github:numtide/flake-utils";
+      url = "github:trueNAHO/flake-utils/lib-each-default-system-pass-through-each-system-pass-through-init";
     };

     git-hooks = {
@@ -905,41 +905,21 @@
         };
       }
     )
-    //
-    # The outputs.homeConfigurations attribute set is not contained in
-    # inputs.flake-utils.lib.eachDefaultSystem to prevent the following invalid
-    # system key injection:
-    #
-    #     outputs.homeConfigurations.${system}.<HOME_CONFIGURATION_NAME>
-    #
-    # Due to the lib.mkMerge function being unavailable in this scope, the
-    # outputs.homeConfigurations attribute set is expanded and merged with the
-    # inputs.flake-utils.lib.defaultSystems values.
-    #
-    # Unlike inputs.flake-utils.lib.eachDefaultSystem, this implementation
-    # merely provides the system argument.
-    {
-      homeConfigurations =
-        builtins.foldl'
-        (
-          acc: system: let
-            lib = pkgs.lib.extend (
-              final: _:
-                import ./lib {
-                  inherit inputs pkgs system;
-
-                  lib = final;
-                  pkgsHyprland = inputs.nixpkgsHyprland.legacyPackages.${system};
-                }
-            );
+    // inputs.flake-utils.lib.eachDefaultSystemPassThrough (
+      system: let
+        lib = pkgs.lib.extend (
+          final: _:
+            import ./lib {
+              inherit inputs pkgs system;

-            pkgs = inputs.nixpkgs.legacyPackages.${system};
-          in
-            lib.attrsets.unionOfDisjoint acc (
-              import ./home_configurations {inherit lib system;}
-            )
-        )
-        {}
-        inputs.flake-utils.lib.defaultSystems;
-    };
+              lib = final;
+              pkgsHyprland = inputs.nixpkgsHyprland.legacyPackages.${system};
+            }
+        );
+
+        pkgs = inputs.nixpkgs.legacyPackages.${system};
+      in {
+        homeConfigurations = import ./home_configurations {inherit lib system;};
+      }
+    );
 }
--
2.45.2
```

---

To ensure a clear and easily reversible commit history, it would be best to avoid merge and squash commits and merge each commit individually.

---

```
NAHO (7):
  readme: remove trailing whitespaces
  lib: eachSystem: reformat using 'nixfmt-rfc-style --width 80'
  lib: eachSystem: improve comments
  lib: eachSystem: inline single-use local variables
  lib: eachSystem: simplify boolean expression
  lib: lib: sort inherit statements
  lib: eachDefaultSystemPassThrough/eachSystemPassThrough: init

 README.md | 13 +++++++++-
 lib.nix   | 72 +++++++++++++++++++++++++++++++++++--------------------
 2 files changed, 58 insertions(+), 27 deletions(-)
```